### PR TITLE
Fix some duplicate cases

### DIFF
--- a/plugin/history-traverse.vim
+++ b/plugin/history-traverse.vim
@@ -20,10 +20,11 @@ else
   if !exists('g:history_indicator_back_inactive')    | let g:history_indicator_back_inactive    = '⇦' | endif
   if !exists('g:history_indicator_forward_active')   | let g:history_indicator_forward_active   = '➡' | endif
   if !exists('g:history_indicator_forward_inactive') | let g:history_indicator_forward_inactive = '⇨' | endif
-  if !exists('g:history_indicator_separator')        | let g:history_indicator_separator        = ' ' | endif
 endif
 
-if !exists('g:history_indicator_separator')        | let g:history_indicator_separator        = ' ' | endif
+if !exists('g:history_indicator_separator')
+  let g:history_indicator_separator = ' ' 
+endif
 
 " Window scope
 let w:buffer_history_list = []

--- a/tests/autoload_functions.vader
+++ b/tests/autoload_functions.vader
@@ -45,6 +45,22 @@ Execute ('does not grow above the max history len value'):
   AssertEqual w:buffer_history_list, ['test_2', 'test_3']
   AssertEqual w:current_buffer_index, 1
 
+Execute ('does not add to the list if the input file is the same as the current buffer index'):
+  :let g:history_max_len = 100
+  :let w:buffer_history_list = ['test_1', 'test_2', 'test_3', 'test_4']
+  :let w:current_buffer_index = 1
+  :call history_traverse#AddToBufferHistoryList('test_2')
+  AssertEqual w:buffer_history_list, ['test_1', 'test_2', 'test_3', 'test_4']
+  AssertEqual w:current_buffer_index, 1
+
+Execute ('does not add to the list if the input file is the same as the next buffer index'):
+  :let g:history_max_len = 100
+  :let w:buffer_history_list = ['test_1', 'test_2', 'test_3', 'test_4']
+  :let w:current_buffer_index = 1
+  :call history_traverse#AddToBufferHistoryList('test_3')
+  AssertEqual w:buffer_history_list, ['test_1', 'test_2', 'test_3', 'test_4']
+  AssertEqual w:current_buffer_index, 2
+
 # Describe history_traverse#HistoryGoBack()
 Execute ('can go back from the end of the list'):
   :let g:history_max_len = 100


### PR DESCRIPTION
Previously it was easy to end up with duplicate files right next to each other in the history list, and it was possible to accidentally chop the end off of the history list by manually opening the file that was actually next in the history list. This commit fixes both of those cases.