### PR TITLE
Add ability to ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ nnoremap <C-n> :HisTravForward<CR>
 " Set filetypes to pass over putting in the history. Defaults to ['netrw']
 let g:history_ft_ignore = ['pyc', 'netrw']
 
+" Set file names to pass over putting in the history. Defaults to an empty list
+let g:history_fn_ignore = ['hate_this_file.py', 'worst_file']
+
 " Set the maximum length of each buffer's history. Defaults to 100
 let g:history_max_len = 1000
 

--- a/plugin/autocmds.vim
+++ b/plugin/autocmds.vim
@@ -17,6 +17,6 @@ augroup history_group
   " Command window specific (fixes an error when you press <c-f> in command mode)
   autocmd! CmdwinEnter * call history_traverse#InitializeWindowSettings()
 
-  autocmd! BufWinEnter * if index(g:history_ft_ignore, &ft) < 0 |
+  autocmd! BufWinEnter * if index(g:history_ft_ignore, &ft) < 0 && index(g:history_fn_ignore, expand('%:t')) < 0 |
         \ call history_traverse#AddToBufferHistoryList(expand('%:p'))
 augroup END

--- a/plugin/history-traverse.vim
+++ b/plugin/history-traverse.vim
@@ -6,7 +6,8 @@ let g:history_traverse_loaded = 1
 
 " Global scope (user settings)
 if !exists('g:history_ft_ignore')   | let g:history_ft_ignore = ['netrw'] | endif
-if !exists('g:history_max_len')     | let g:history_max_len = 100         | endif
+if !exists('g:history_fn_ignore')   | let g:history_fn_ignore = []        | endif
+if !exists('g:history_max_len')     | let g:history_max_len   = 100       | endif
 
 if has('gui_running')
   if !exists('g:history_indicator_back_active')      | let g:history_indicator_back_active      = '◀' | endif

--- a/tests/autoload_functions.vader
+++ b/tests/autoload_functions.vader
@@ -128,6 +128,7 @@ Before (in the middle of the history list with three files):
   redir END
   let g:history_max_len = 100
   let g:test_messages = ''
+  let g:history_fn_ignore = ['file_to_ignore.extension']
   let w:buffer_history_list = []
   let w:current_buffer_index = 0
   edit test_1
@@ -173,3 +174,18 @@ Execute (go forward when the index is too high):
 Then (resets the state of the index):
   AssertEqual w:buffer_history_list, map(['/test_1', '/test_2', '/test_3'], 'expand("%:p:h") . v:val')
   AssertEqual expand('%:p'), w:buffer_history_list[1]
+
+Execute (go to a buffer on the file ignore list):
+  edit file_to_ignore.extension
+
+Then (goes to the file but doesn\'t add it to the history list):
+  AssertEqual w:buffer_history_list, map(['/test_1', '/test_2', '/test_3'], 'expand("%:p:h") . v:val')
+  AssertEqual expand('%:p'), expand('%:p:h') . '/file_to_ignore.extension'
+
+Execute (go to a buffer on the file ignore list, then go to a new file):
+  edit file_to_ignore.extension
+  edit test_4
+
+Then (goes to the new file and cuts the end off of the remaining history list):
+  AssertEqual w:buffer_history_list, map(['/test_1', '/test_2', '/test_4'], 'expand("%:p:h") . v:val')
+  AssertEqual expand('%:p'), w:buffer_history_list[2]

--- a/tests/history_indicator.vader
+++ b/tests/history_indicator.vader
@@ -2,41 +2,41 @@
 
 # Describe history_traverse#HistoryIndicator()
 Execute ('returns the expected history indicators in the initial empty state'):
-  :let g:history_max_len = 100
-  :let w:buffer_history_list = []
-  :let w:current_buffer_index = 0
-  :let b:expected_indicator = g:history_indicator_back_inactive 
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_inactive
-  :let b:actual_indicator = HistoryIndicator()
+  let g:history_max_len = 100
+  let w:buffer_history_list = []
+  let w:current_buffer_index = 0
+  let b:expected_indicator = g:history_indicator_back_inactive 
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_inactive
+  let b:actual_indicator = HistoryIndicator()
   AssertEqual b:actual_indicator, b:expected_indicator
 
 Execute ('returns expected history indicators while at the head of the non-empty history'):
-  :let g:history_max_len = 100
-  :let w:buffer_history_list = ['test_filename1', 'test_filename2']
-  :let w:current_buffer_index = 1
-  :let b:expected_indicator = g:history_indicator_back_active 
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_inactive
-  :let b:actual_indicator = HistoryIndicator()
+  let g:history_max_len = 100
+  let w:buffer_history_list = ['test_filename1', 'test_filename2']
+  let w:current_buffer_index = 1
+  let b:expected_indicator = g:history_indicator_back_active 
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_inactive
+  let b:actual_indicator = HistoryIndicator()
   AssertEqual b:actual_indicator, b:expected_indicator
 
 Execute ('returns expected history indicators while at the tail of the non-empty history'):
-  :let g:history_max_len = 100
-  :let w:buffer_history_list = ['test_filename1', 'test_filename2']
-  :let w:current_buffer_index = 0
-  :let b:expected_indicator = g:history_indicator_back_inactive 
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_active
-  :let b:actual_indicator = HistoryIndicator()
+  let g:history_max_len = 100
+  let w:buffer_history_list = ['test_filename1', 'test_filename2']
+  let w:current_buffer_index = 0
+  let b:expected_indicator = g:history_indicator_back_inactive 
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_active
+  let b:actual_indicator = HistoryIndicator()
   AssertEqual b:actual_indicator, b:expected_indicator
 
 Execute ('returns expected history indicators while in the middle of the non-empty history'):
-  :let g:history_max_len = 100
-  :let w:buffer_history_list = ['test_filename1', 'test_filename2', 'test_filename3']
-  :let w:current_buffer_index = 1
-  :let b:expected_indicator = g:history_indicator_back_active 
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
-  :let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_active
-  :let b:actual_indicator = HistoryIndicator()
+  let g:history_max_len = 100
+  let w:buffer_history_list = ['test_filename1', 'test_filename2', 'test_filename3']
+  let w:current_buffer_index = 1
+  let b:expected_indicator = g:history_indicator_back_active 
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_separator
+  let b:expected_indicator = b:expected_indicator . g:history_indicator_forward_active
+  let b:actual_indicator = HistoryIndicator()
   AssertEqual b:actual_indicator, b:expected_indicator


### PR DESCRIPTION
Add a config option for ignoring files by name. If the file has an extension, it must be included in the name.